### PR TITLE
Solve bug when loading traffic in K6 via https instead of http

### DIFF
--- a/pkg/performance/utils.go
+++ b/pkg/performance/utils.go
@@ -851,7 +851,7 @@ func generateSimpleTrafficLoadK6(protocol string, app string) error {
 		if errRoute != nil {
 			return fmt.Errorf("route %s not found in namespace %s", appName, meshNamespace)
 		} else {
-			url = "https://" + routeHost + "/productpage"
+			url = "http://" + routeHost + "/productpage"
 		}
 		_, err = execK6SyncTest(testVUs, testDuration, url, "http-basic.js", reportFile)
 


### PR DESCRIPTION
I don't know when this changed. But we are not deploying Bookinfo via HTTPS, so it makes no sense to do load testing through HTTPS