### PR TITLE
Solve loading traffic bug and eliminate redundancy in logs when having errors

### DIFF
--- a/pkg/performance/application.go
+++ b/pkg/performance/application.go
@@ -13,7 +13,6 @@ func CreateTestCPObjects(t *testing.T) {
 	err := createAppBundle(trafficLoadApp, apps, "controlplane")
 	if err != nil {
 		util.Log.Error(err)
-		t.Error(err)
 		t.FailNow()
 	}
 }
@@ -24,7 +23,6 @@ func DeleteTestCPObjects(t *testing.T) {
 	err := deleteAppBundle(trafficLoadApp, apps, "controlplane")
 	if err != nil {
 		util.Log.Error(err)
-		t.Error(err)
 		t.FailNow()
 	}
 }
@@ -35,7 +33,6 @@ func CreateTestDPObjects(t *testing.T) {
 	err := createAppBundle(trafficLoadApp, apps, "dataplane")
 	if err != nil {
 		util.Log.Error(err)
-		t.Error(err)
 		t.FailNow()
 	}
 }
@@ -46,7 +43,6 @@ func DeleteTestDPObjects(t *testing.T) {
 	err := deleteAppBundle(trafficLoadApp, apps, "dataplane")
 	if err != nil {
 		util.Log.Error(err)
-		t.Error(err)
 		t.FailNow()
 	}
 }

--- a/pkg/performance/k6.go
+++ b/pkg/performance/k6.go
@@ -12,7 +12,6 @@ func GenerateTrafficLoadK6(t *testing.T) {
 	err := generateSimpleTrafficLoadK6(trafficLoadProtocol, trafficLoadApp)
 	if err != nil {
 		util.Log.Error(err)
-		t.Error(err)
 		t.FailNow()
 	}
 	util.Log.Info("OK: k6 load test executed")
@@ -23,21 +22,18 @@ func AnalyseLoadK6Output(t *testing.T) {
 	dat, err := readK6File()
 	if err != nil {
 		util.Log.Error(err)
-		t.Error(err)
 		t.FailNow()
 	}
 
 	res, err := parseK6Response(dat)
 	if err != nil {
 		util.Log.Error(err)
-		t.Error(err)
 		t.FailNow()
 	}
 
 	result, err := checkFailedMetrics(res.Metrics.Checks.Fails)
 	if err != nil {
 		util.Log.Error(err)
-		t.Error(err)
 		t.FailNow()
 	} else {
 		util.Log.Info(result)
@@ -50,14 +46,12 @@ func AnalyseLoadK6Output(t *testing.T) {
 		p95 = res.Metrics.GrpcReqDuration.P95
 	} else {
 		util.Log.Error("Protocol not valid")
-		t.Error(err)
 		t.FailNow()
 	}
 
 	result, err = compareP95(fmt.Sprintf("%f", p95), reqAvg95pAcceptanceTime)
 	if err != nil {
 		util.Log.Error(err)
-		t.Error(err)
 		t.FailNow()
 	}
 

--- a/pkg/performance/metrics.go
+++ b/pkg/performance/metrics.go
@@ -11,33 +11,28 @@ func TestXDSPushes(t *testing.T) {
 	xdsPushCount, err := getMetricPrometheusMesh("xds_ppctc")
 	if err != nil {
 		util.Log.Error(err)
-		t.Error(err)
 		t.FailNow()
 	}
 	xdsPushTime, err := getMetricPrometheusMesh("xds_ppctb")
 	if err != nil {
 		util.Log.Error(err)
-		t.Error(err)
 		t.FailNow()
 	}
 
 	xdsPushCountValue, err := parsePromResponse([]byte(xdsPushCount))
 	if err != nil {
 		util.Log.Error(err)
-		t.Error(err)
 		t.FailNow()
 	}
 	xdsPushTimeValue, err := parsePromResponse([]byte(xdsPushTime))
 	if err != nil {
 		util.Log.Error(err)
-		t.Error(err)
 		t.FailNow()
 	}
 
 	for i := 0; i < len(xdsPushCountValue); i++ {
 		if xdsPushCountValue[i] != xdsPushTimeValue[i] {
-			util.Log.Error(err)
-			t.Errorf("xdsPushCount (%v) and xdsPushTime (%v) are not equal and some requests are higher than %s seconds", xdsPushCountValue, xdsPushTimeValue, xdsPushAcceptanceTime)
+			util.Log.Errorf("xdsPushCount (%v) and xdsPushTime (%v) are not equal and some requests are higher than %s seconds", xdsPushCountValue, xdsPushTimeValue, xdsPushAcceptanceTime)
 			t.FailNow()
 		} else {
 			util.Log.Info("OK: ", xdsPushCountValue[i], "/", xdsPushTimeValue[i], " correct XDS pushes")
@@ -53,21 +48,18 @@ func TestXDSErrors(t *testing.T) {
 		xdsError, err := getMetricPrometheusMesh(metric)
 		if err != nil {
 			util.Log.Error(err)
-			t.Error(err)
 			t.FailNow()
 		}
 
 		xdsErrorValue, err := parsePromResponse([]byte(xdsError))
 		if err != nil {
 			util.Log.Error(err)
-			t.Error(err)
 			t.FailNow()
 		}
 
 		for i := 0; i < len(xdsErrorValue); i++ {
 			if xdsErrorValue[i] != "0" {
-				util.Log.Error(err)
-				t.Error("XDS has errors. Failure in metric: ", metric)
+				util.Log.Error("XDS has errors. Failure in metric: ", metric)
 				t.FailNow()
 			} else {
 				util.Log.Info("OK: ", xdsErrorValue[i], " errors -- ", usage)
@@ -82,7 +74,6 @@ func TestIstiodMem(t *testing.T) {
 	meshPods, err := getMeshProxies("istiod")
 	if err != nil {
 		util.Log.Error(err)
-		t.Error(err)
 		t.FailNow()
 	}
 	for name, namespace := range meshPods {
@@ -91,21 +82,18 @@ func TestIstiodMem(t *testing.T) {
 		istiodProxyMem, err := getMetricPrometheusOCP("istio_proxies_mem_custom", prometheusAPIMapParams)
 		if err != nil {
 			util.Log.Error(err)
-			t.Error(err)
 			t.FailNow()
 		}
 
 		istiodMemValue, err := parsePromResponse([]byte(istiodProxyMem))
 		if err != nil {
 			util.Log.Error(err)
-			t.Error(err)
 			t.FailNow()
 		}
 
 		result, errComp := comparePodsMem(istiodMemValue[0], istiodAcceptanceMem)
 		if errComp != nil {
 			util.Log.Error(err)
-			t.Error(err)
 			t.FailNow()
 		} else {
 			util.Log.Info(result, " (pod/namespace: ", name, "/", namespace, ")")
@@ -119,7 +107,6 @@ func TestIstiodCpu(t *testing.T) {
 	meshPods, err := getMeshProxies("istiod")
 	if err != nil {
 		util.Log.Error(err)
-		t.Error(err)
 		t.FailNow()
 	}
 
@@ -129,21 +116,18 @@ func TestIstiodCpu(t *testing.T) {
 		istiodCpu, err := getMetricPrometheusOCP("istio_proxies_cpu_custom", prometheusAPIMapParams)
 		if err != nil {
 			util.Log.Error(err)
-			t.Error(err)
 			t.FailNow()
 		}
 
 		istiodCpuValue, err := parsePromResponse([]byte(istiodCpu))
 		if err != nil {
 			util.Log.Error(err)
-			t.Error(err)
 			t.FailNow()
 		}
 
 		result, errComp := comparePodsCpu(istiodCpuValue[0], istiodAcceptanceCpu)
 		if errComp != nil {
 			util.Log.Error(err)
-			t.Error(err)
 			t.FailNow()
 		} else {
 			util.Log.Info(result, " (pod/namespace: ", name, "/", namespace, ")")
@@ -157,7 +141,6 @@ func TestIstioProxiesMem(t *testing.T) {
 	meshPods, err := getMeshProxies("proxy")
 	if err != nil {
 		util.Log.Error(err)
-		t.Error(err)
 		t.FailNow()
 	}
 	for name, namespace := range meshPods {
@@ -166,14 +149,12 @@ func TestIstioProxiesMem(t *testing.T) {
 		istioProxyMem, err := getMetricPrometheusOCP("istio_proxies_mem_custom", prometheusAPIMapParams)
 		if err != nil {
 			util.Log.Error(err)
-			t.Error(err)
 			t.FailNow()
 		}
 
 		istioProxyMemValue, err := parsePromResponse([]byte(istioProxyMem))
 		if err != nil {
 			util.Log.Error(err)
-			t.Error(err)
 			t.FailNow()
 		}
 
@@ -181,7 +162,6 @@ func TestIstioProxiesMem(t *testing.T) {
 			result, errComp := comparePodsMem(istioProxyMemValue[0], istioProxiesAcceptanceMem)
 			if errComp != nil {
 				util.Log.Error(err)
-				t.Error(err)
 				t.FailNow()
 			} else {
 				util.Log.Info(result, " (pod/namespace: ", name, "/", namespace, ")")
@@ -199,7 +179,6 @@ func TestIstioProxiesCpu(t *testing.T) {
 	meshPods, err := getMeshProxies("proxy")
 	if err != nil {
 		util.Log.Error(err)
-		t.Error(err)
 		t.FailNow()
 	}
 	for name, namespace := range meshPods {
@@ -208,14 +187,12 @@ func TestIstioProxiesCpu(t *testing.T) {
 		istioProxyCpu, err := getMetricPrometheusOCP("istio_proxies_cpu_custom", prometheusAPIMapParams)
 		if err != nil {
 			util.Log.Error(err)
-			t.Error(err)
 			t.FailNow()
 		}
 
 		istioProxyCpuValue, err := parsePromResponse([]byte(istioProxyCpu))
 		if err != nil {
 			util.Log.Error(err)
-			t.Error(err)
 			t.FailNow()
 		}
 
@@ -223,7 +200,6 @@ func TestIstioProxiesCpu(t *testing.T) {
 			result, errComp := comparePodsCpu(istioProxyCpuValue[0], istioProxiesAcceptanceCpu)
 			if errComp != nil {
 				util.Log.Error(err)
-				t.Error(err)
 				t.FailNow()
 			} else {
 				util.Log.Info(result, " (pod/namespace: ", name, "/", namespace, ")")
@@ -241,7 +217,6 @@ func TestIstioIngressMem(t *testing.T) {
 	meshPods, err := getMeshProxies("ingress")
 	if err != nil {
 		util.Log.Error(err)
-		t.Error(err)
 		t.FailNow()
 	}
 
@@ -251,21 +226,18 @@ func TestIstioIngressMem(t *testing.T) {
 		istioIngressProxyMem, err := getMetricPrometheusOCP("istio_proxies_mem_custom", prometheusAPIMapParams)
 		if err != nil {
 			util.Log.Error(err)
-			t.Error(err)
 			t.FailNow()
 		}
 
 		istioIngressMemValue, err := parsePromResponse([]byte(istioIngressProxyMem))
 		if err != nil {
 			util.Log.Error(err)
-			t.Error(err)
 			t.FailNow()
 		}
 
 		result, errComp := comparePodsMem(istioIngressMemValue[0], istioIngressAcceptanceMem)
 		if errComp != nil {
 			util.Log.Error(err)
-			t.Error(err)
 			t.FailNow()
 		} else {
 			util.Log.Info(result, " (pod/namespace: ", name, "/", namespace, ")")
@@ -279,7 +251,6 @@ func TestIstioIngressCpu(t *testing.T) {
 	meshPods, err := getMeshProxies("ingress")
 	if err != nil {
 		util.Log.Error(err)
-		t.Error(err)
 		t.FailNow()
 	}
 	for name, namespace := range meshPods {
@@ -288,21 +259,18 @@ func TestIstioIngressCpu(t *testing.T) {
 		istioIngressCpu, err := getMetricPrometheusOCP("istio_proxies_cpu_custom", prometheusAPIMapParams)
 		if err != nil {
 			util.Log.Error(err)
-			t.Error(err)
 			t.FailNow()
 		}
 
 		istioIngressCpuValue, err := parsePromResponse([]byte(istioIngressCpu))
 		if err != nil {
 			util.Log.Error(err)
-			t.Error(err)
 			t.FailNow()
 		}
 
 		result, errComp := comparePodsCpu(istioIngressCpuValue[0], istioIngressAcceptanceCpu)
 		if errComp != nil {
 			util.Log.Error(err)
-			t.Error(err)
 			t.FailNow()
 		} else {
 			util.Log.Info(result, " (pod/namespace: ", name, "/", namespace, ")")
@@ -316,7 +284,6 @@ func TestIstioEgressMem(t *testing.T) {
 	meshPods, err := getMeshProxies("egress")
 	if err != nil {
 		util.Log.Error(err)
-		t.Error(err)
 		t.FailNow()
 	}
 	for name, namespace := range meshPods {
@@ -325,21 +292,18 @@ func TestIstioEgressMem(t *testing.T) {
 		istioEgressProxyMem, err := getMetricPrometheusOCP("istio_proxies_mem_custom", prometheusAPIMapParams)
 		if err != nil {
 			util.Log.Error(err)
-			t.Error(err)
 			t.FailNow()
 		}
 
 		istioEgressMemValue, err := parsePromResponse([]byte(istioEgressProxyMem))
 		if err != nil {
 			util.Log.Error(err)
-			t.Error(err)
 			t.FailNow()
 		}
 
 		result, errComp := comparePodsMem(istioEgressMemValue[0], istioEgressAcceptanceMem)
 		if errComp != nil {
 			util.Log.Error(err)
-			t.Error(err)
 			t.FailNow()
 		} else {
 			util.Log.Info(result, " (pod/namespace: ", name, "/", namespace, ")")
@@ -353,7 +317,6 @@ func TestIstioEgressCpu(t *testing.T) {
 	meshPods, err := getMeshProxies("egress")
 	if err != nil {
 		util.Log.Error(err)
-		t.Error(err)
 		t.FailNow()
 	}
 	for name, namespace := range meshPods {
@@ -362,21 +325,18 @@ func TestIstioEgressCpu(t *testing.T) {
 		istioEgressProxyCpu, err := getMetricPrometheusOCP("istio_proxies_cpu_custom", prometheusAPIMapParams)
 		if err != nil {
 			util.Log.Error(err)
-			t.Error(err)
 			t.FailNow()
 		}
 
 		istioEgressCpuValue, err := parsePromResponse([]byte(istioEgressProxyCpu))
 		if err != nil {
 			util.Log.Error(err)
-			t.Error(err)
 			t.FailNow()
 		}
 
 		result, errComp := comparePodsCpu(istioEgressCpuValue[0], istioEgressAcceptanceCpu)
 		if errComp != nil {
 			util.Log.Error(err)
-			t.Error(err)
 			t.FailNow()
 		} else {
 			util.Log.Info(result, " (pod/namespace: ", name, "/", namespace, ")")

--- a/pkg/performance/ns_creation.go
+++ b/pkg/performance/ns_creation.go
@@ -32,7 +32,6 @@ func testNamespaceAdditionTime(index int, acceptanceTime int) error {
 
 	// Check addition time
 	if duration > acceptanceTimeMS {
-		util.Log.Error("Acceptance time exceeded")
 		return fmt.Errorf("acceptance time exceeded")
 	}
 	util.Log.Info("Duration OK: ", duration, " milliseconds")

--- a/pkg/performance/utils.go
+++ b/pkg/performance/utils.go
@@ -23,7 +23,6 @@ func TestSMCP(t *testing.T) {
 	msg, _ := util.ShellSilent(`oc wait --for condition=Ready -n %s smcp/%s --timeout 30s`, meshNamespace, smcpName)
 	if !strings.Contains(msg, "condition met") {
 		util.Log.Error("SMCP not Ready")
-		t.Error("SMCP not Ready")
 		t.FailNow()
 	}
 	util.Log.Info("OK - SMCP ", smcpName, " in namespace ", meshNamespace)
@@ -33,7 +32,6 @@ func TestSMMR(t *testing.T) {
 	msg, _ := util.ShellSilent(`oc wait --for condition=Ready -n %s smmr/default --timeout 30s`, meshNamespace)
 	if !strings.Contains(msg, "condition met") {
 		util.Log.Error("SMMR not Ready")
-		t.Error("SMMR not Ready")
 		t.FailNow()
 	}
 	util.Log.Info("OK - SMMR in namespace ", meshNamespace)
@@ -957,5 +955,4 @@ func calculateAppsFillCluster(app string) (int, error) {
 	} else {
 		return memNumApp, nil
 	}
-
 }

--- a/pkg/performance/utils.go
+++ b/pkg/performance/utils.go
@@ -851,7 +851,7 @@ func generateSimpleTrafficLoadK6(protocol string, app string) error {
 		if errRoute != nil {
 			return fmt.Errorf("route %s not found in namespace %s", appName, meshNamespace)
 		} else {
-			url = "https://" + routeHost + "/productpage"
+			url = "http://" + routeHost + "/productpage"
 		}
 		_, err = execK6SyncTest(testVUs, testDuration, url, "http-basic.js", reportFile)
 


### PR DESCRIPTION
- Solve a bug when loading traffic in K6 via HTTPS instead of HTTP. (Replaces PR #22)
- Solve redundancy in log messages when having errors