### PR TITLE
Fix output logging of certain commands

### DIFF
--- a/pkg/performance/apps_bookinfo.go
+++ b/pkg/performance/apps_bookinfo.go
@@ -39,20 +39,20 @@ func (b *Bookinfo) BookinfoInstall(mtls bool) error {
 	}
 
 	util.Log.Debug("Creating Gateway from template")
-	err = util.KubeApplyContents(b.Namespace, util.RunTemplate(bookinfoGatewayTemplate, b))
+	err = util.KubeApplyContentSilent(b.Namespace, util.RunTemplate(bookinfoGatewayTemplate, b))
 	if err != nil {
 		return err
 	}
 
 	util.Log.Debug("Creating VirtualService from template")
-	err = util.KubeApplyContents(b.Namespace, util.RunTemplate(bookinfoVirtualServiceTemplate, b))
+	err = util.KubeApplyContentSilent(b.Namespace, util.RunTemplate(bookinfoVirtualServiceTemplate, b))
 	if err != nil {
 		return err
 	}
 
 	util.Log.Debug("Creating Route from template")
 	r := Route{Name: b.Namespace, Namespace: meshNamespace, Host: b.Host, Service: "istio-ingressgateway"}
-	err = util.KubeApplyContents(meshNamespace, util.RunTemplate(bookinfoSimpleHTTPRouteTemplate, r))
+	err = util.KubeApplyContentSilent(meshNamespace, util.RunTemplate(bookinfoSimpleHTTPRouteTemplate, r))
 	if err != nil {
 		return err
 	}

--- a/pkg/performance/apps_jumpapp.go
+++ b/pkg/performance/apps_jumpapp.go
@@ -8,7 +8,7 @@ import (
 
 func (b *JumpApp) JumpappInstall() error {
 	util.Log.Info("Deploying JumpAppin ", b.Namespace)
-	err := util.KubeApply(b.Namespace, jumpappYaml)
+	err := util.KubeApplySilent(b.Namespace, jumpappYaml)
 	if err != nil {
 		return err
 	}
@@ -30,7 +30,7 @@ func (b *JumpApp) JumpappInstall() error {
 		return err
 	}
 
-	err = util.KubeApply(b.Namespace, jumpappNetworking)
+	err = util.KubeApplySilent(b.Namespace, jumpappNetworking)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Some of the KubeApply commands were printing their outputs and were not looking good in the logs